### PR TITLE
Use babel jsxPragma option.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "stage": 0
+  "stage": 0,
+  "jsxPragma": "Yolk.createElement"
 }

--- a/js/App.jsx
+++ b/js/App.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function App (props) {
   const {filter, todos} = props
 

--- a/js/CompleteButton.jsx
+++ b/js/CompleteButton.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function CompleteButton () {
   const handleClear = this.createEventHandler()
 

--- a/js/FilterSelect.jsx
+++ b/js/FilterSelect.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function FilterSelect (props) {
   const {filter} = props
 

--- a/js/Footer.jsx
+++ b/js/Footer.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function Footer () {
   return (
     <footer className="info">

--- a/js/Header.jsx
+++ b/js/Header.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function Header () {
   const handleSubmit = this.createEventHandler(ev => ev.preventDefault())
   const handleChange = this.createEventHandler(ev => ev.target.value)

--- a/js/Main.jsx
+++ b/js/Main.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function Main (props) {
   const {filter, todos} = props
 

--- a/js/TodoCount.jsx
+++ b/js/TodoCount.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function TodoCount (props) {
   const count = props.todos.flatMap(todos => {
     return Rx.Observable.from(todos)

--- a/js/TodoItem.jsx
+++ b/js/TodoItem.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function TodoItem (props) {
   const {todo} = props
 

--- a/js/TodoList.jsx
+++ b/js/TodoList.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function TodoList (props) {
   const {todos, filter} = props
 

--- a/js/ToggleAllButton.jsx
+++ b/js/ToggleAllButton.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 function ToggleAllButton () {
   const handleChange = this.createEventHandler(null, true)
   const checked = handleChange.scan(acc => !acc, true)

--- a/js/index.jsx
+++ b/js/index.jsx
@@ -1,5 +1,3 @@
-/** @jsx Yolk.createElement */
-
 const todoStore = new TodoStore()
 const filterStore = new FilterStore()
 TodoActions.register(todoStore.updates)


### PR DESCRIPTION
Using Babel's `jsxPragma` option reduces duplication and makes changes like 72a599df70b09b0e2177c2c7e87e32c7c5a6ffdb easier.